### PR TITLE
Fix BiMap.put/3 mapping update issue

### DIFF
--- a/lib/bimap.ex
+++ b/lib/bimap.ex
@@ -353,7 +353,8 @@ defmodule BiMap do
       #BiMap<[a: "foo"]>
   """
   @spec put(t, k, v) :: t
-  def put(%BiMap{keys: keys, values: values} = bimap, key, value) do
+  def put(%BiMap{} = bimap, key, value) do
+    %{keys: keys, values: values} = bimap |> BiMap.delete_key(key) |> BiMap.delete_value(value)
     %{bimap | keys: Map.put(keys, key, value), values: Map.put(values, value, key)}
   end
 

--- a/test/bimap_properties_test.exs
+++ b/test/bimap_properties_test.exs
@@ -54,8 +54,8 @@ defmodule BiMapPropertiesTest do
   end
 
   property "it puts items into bimaps" do
-    check all key_set <- nonempty(uniq_list_of(term())),
-              value_set <- uniq_list_of(term(), length: Enum.count(key_set)),
+    check all key_set <- nonempty(uniq_list_of(atom(:alphanumeric))),
+              value_set <- uniq_list_of(integer(), length: Enum.count(key_set)),
               random_key <- term(),
               random_value <- term() do
       regular_map = Enum.zip(key_set, value_set) |> Enum.into(%{})


### PR DESCRIPTION
Wrote a patch to resolve the issue identified in #4.  It simply removes any existing reverse-mappings prior to updating the BiMap.  Added a test to ensure that `BiMap.put/3` updates correctly.

Because of failures with the random StreamData, I modified the `it puts items into bimaps` test to use a single type when generating the initial map.  Keys are now always atoms, and values are always integers.